### PR TITLE
feat: relax telemetry schema for firmware/integration realities

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,26 +25,52 @@ API available at `http://localhost:8000`
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/health` | Health check |
-| POST | `/api/v1/ingest/telemetry` | Ingest drone telemetry |
-| GET | `/api/v1/stream/telemetry?drone_id=X` | SSE telemetry stream |
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| GET | `/health` | Health check | — |
+| POST | `/api/v1/ingest/telemetry` | Ingest drone telemetry | `X-API-Key` |
+| GET | `/api/v1/stream/telemetry?drone_id=X` | SSE telemetry stream | — |
+
+## Auth (drone-side)
+
+Drones authenticate to `/ingest/telemetry` with a per-drone API key in the
+`X-API-Key` header. Keys are vendor-managed — minted and revoked via CLIs:
+
+```bash
+# Mint a key for a drone (must already exist as a DB row)
+uv run python -m scripts.mint_key --org-slug <org> --drone-slug <drone> --label "<purpose>"
+
+# Revoke a single key by its 8-hex prefix
+uv run python -m scripts.revoke_key --prefix <prefix>
+
+# Revoke every active key on a drone (break-glass)
+uv run python -m scripts.revoke_key --org-slug <org> --drone-slug <drone>
+```
+
+Output of `mint_key` is the raw key (`sk_drone_<prefix>_<secret>`). Copy once;
+only the prefix and SHA-256 hash are stored. `verify_api_key` logs a distinct
+reason per failure path (`bad_format`, `unknown_prefix`, `hash_mismatch`,
+`revoked_key`, `inactive_drone`) — `revoked_key` is the high-priority signal.
 
 ## Project structure
 
 ```
 app/
 ├── api/v1/
-│   ├── ingest.py      # Telemetry ingest endpoint
+│   ├── ingest.py      # Telemetry ingest endpoint (X-API-Key required)
 │   └── stream.py      # SSE streaming endpoint
+├── auth/
+│   ├── api_key.py     # Key generation, parsing, verification (with granular logging)
+│   └── dependencies.py# FastAPI dep: get_current_drone via X-API-Key
 ├── core/
 │   ├── config.py      # Pydantic settings
 │   ├── database.py    # Async SQLAlchemy engine
 │   └── redis.py       # Async Redis client
 ├── models/
 │   ├── base.py        # SQLAlchemy declarative base
-│   └── telemetry.py   # TelemetryRecord model
+│   ├── org.py         # Org (tenant)
+│   ├── drone.py       # Drone (org-scoped)
+│   └── drone_api_key.py # Hashed API key (prefix + hash, never plaintext)
 ├── schemas/
 │   └── telemetry.py   # Pydantic request models
 └── main.py            # FastAPI app setup + router includes
@@ -52,5 +78,7 @@ alembic/
 ├── env.py             # Async migration runner
 └── versions/          # Migration files
 scripts/
+├── mint_key.py        # Operator CLI: issue a drone API key
+├── revoke_key.py      # Operator CLI: revoke a key (by prefix or by drone)
 └── simulate_drone.py  # Dev telemetry simulator
 ```

--- a/app/schemas/telemetry.py
+++ b/app/schemas/telemetry.py
@@ -1,8 +1,4 @@
 from pydantic import BaseModel, Field
-from typing import Literal
-
-
-FLIGHT_MODE = Literal["STABILIZE", "ALT_HOLD", "LOITER", "AUTO", "RTL", "LAND", "GUIDED", "POSHOLD", "BRAKE",]
 
 
 class TelemetryPayload(BaseModel):
@@ -11,12 +7,18 @@ class TelemetryPayload(BaseModel):
     """
     lat: float = Field(..., ge=-90, le=90)
     lon: float = Field(..., ge=-180, le=180)
-    alt: float = Field(..., ge=0, le=10000)
+    # MAVLink relative_alt is signed (above-home displacement). Negatives are
+    # legitimate: rooftop takeoff with ground descent, valley/mine surveys,
+    # GPS noise around home. Lower bound is a sanity ceiling, not a physics one.
+    alt: float = Field(..., ge=-1000, le=10000)
     speed: float = Field(..., ge=0, le=200)
     heading: int = Field(..., ge=0, lt=360)
     battery: float = Field(..., ge=0, le=100)
     voltage: float = Field(..., ge=0, le=60)
     armed: bool
-    flight_mode: FLIGHT_MODE
+    # Pattern-validated rather than enum-closed. Decouples cloud schema
+    # from firmware mode catalogs (ArduCopter/Plane/Rover all differ);
+    # accepts UNKNOWN during the boot window before first HEARTBEAT.
+    flight_mode: str = Field(..., min_length=1, max_length=32, pattern=r"^[A-Z0-9_]+$")
     gps_fix_type: int = Field(..., ge=0, le=8)
     satellites: int = Field(..., ge=0, le=64)

--- a/devlog.md
+++ b/devlog.md
@@ -110,3 +110,21 @@ Chronological record of development decisions, progress, and open questions.
 - Logging conventions: snake_case event names, structured keyword args, no credentials in logs
 - Replaced all `print()` with structured log calls
 - Health check logging: only log failures (success checks are high-frequency noise)
+
+## 2026-04-23 — Vendor-managed API key auth on telemetry ingest
+
+- New tables: `orgs`, `drones`, `drone_api_keys` (consolidated migration replaces old telemetry-only table)
+- `app/auth/api_key.py` — key generation (`sk_drone_<prefix>_<secret>`), prefix/hash split for O(log n) lookup with constant-time hash compare, debounced `last_used_at` update (60s) to avoid 600 UPDATE/min/drone at 10 Hz
+- `app/auth/dependencies.py` — `get_current_drone` FastAPI dep reads `X-API-Key` header, returns authenticated `Drone`. Handlers never trust drone_id from request body.
+- Ingest endpoint reads drone identity from the dep, removed `drone_id` from `TelemetryPayload`. Pydantic schema gained range validators (lat/lon/alt/speed/heading/battery/voltage/gps_fix_type/satellites) plus closed `Literal` flight_mode catalog.
+- Auth model is **vendor-managed**: we mint/revoke, clients contact us. No HTTP admin surface — operator CLIs only (`scripts/mint_key.py`, `scripts/revoke_key.py`). Decision recorded as project memory; defers human-auth design until customer-facing self-service is needed.
+- Rotation strategy: routine rotation via future `POST /auth/rotate` (drone uses current key to mint new), emergency re-key via Tailscale SSH (we have root on drones; clients don't have sudo). Bootstrap-credential separation deferred until fleet scale demands it.
+- Test infra: `authed_drone` and `unkeyed_drone` fixtures. Tests verify keys actually authenticate via `verify_api_key` round-trip after mint, and stop authenticating after revoke — not just DB state changes. `expire_on_commit=False` on the test session to mirror production session config (the alternative was a `MissingGreenlet` error after `verify_api_key`'s commit expires the loaded `drone` instance).
+- Granular auth-failure logging: `verify_api_key` fetches keys without filtering revoked/inactive, branches in Python, logs distinct `reason` per failure (`bad_format`, `unknown_prefix`, `hash_mismatch`, `revoked_key`, `inactive_drone`). `revoked_key` is the high-priority security signal — someone using a key we explicitly killed is now visible.
+- PR #44.
+
+## 2026-04-25 — Telemetry schema relaxation (driven by onboard integration)
+
+- Replaced closed `Literal` flight_mode with permissive pattern: `min_length=1, max_length=32, pattern=r"^[A-Z0-9_]+$"`. Decouples cloud schema from firmware mode catalogs (ArduCopter / Plane / Rover all differ); accepts `UNKNOWN` during the boot window before first HEARTBEAT. Closed enum was creating a deploy-ordering coupling: every new firmware mode would have required a cloud redeploy.
+- Relaxed `alt` lower bound from `ge=0` to `ge=-1000`. MAVLink `relative_alt` is signed (above-home displacement) — negatives are real: rooftop takeoff with ground descent, valley/mine surveys, GPS noise around home. The original `ge=0` reflected an unsigned-MSL mental model that didn't match the wire format. Lower bound is now a sanity ceiling, not a physics one.
+- Test parametrize updated on both sides: rejection cases pin the new boundaries (`alt=-1001`, `flight_mode="manual"`, `flight_mode="ALT-HOLD"`, 33-char flight_mode); new acceptance parametrize covers `UNKNOWN`/`MANUAL`/`ACRO` flight modes and negative/zero/boundary altitudes — the tests now nail down both sides of the contract.

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -47,7 +47,7 @@ async def test_wrong_type_rejected():
         ("lat", -91.0),
         ("lon", 181.0),
         ("lon", -181.0),
-        ("alt", -1.0),
+        ("alt", -1001.0),
         ("alt", 10_001.0),
         ("speed", -1.0),
         ("speed", 201.0),
@@ -61,8 +61,10 @@ async def test_wrong_type_rejected():
         ("gps_fix_type", 9),
         ("satellites", -1),
         ("satellites", 65),
-        ("flight_mode", "MANUAL"),
-        ("flight_mode", ""),
+        ("flight_mode", ""),                # min_length violation
+        ("flight_mode", "manual"),          # lowercase rejected by pattern
+        ("flight_mode", "ALT-HOLD"),        # hyphen rejected by pattern
+        ("flight_mode", "X" * 33),          # max_length violation
     ],
 )
 async def test_out_of_range_rejected(field, bad_value):
@@ -70,3 +72,27 @@ async def test_out_of_range_rejected(field, bad_value):
     data[field] = bad_value
     with pytest.raises(ValidationError):
         TelemetryPayload(**data)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["UNKNOWN", "STABILIZE", "ALT_HOLD", "MANUAL", "ACRO", "POSHOLD"],
+)
+async def test_flight_mode_accepts_any_uppercase_underscore_string(mode):
+    data = _valid_data()
+    data["flight_mode"] = mode
+    payload = TelemetryPayload(**data)
+    assert payload.flight_mode == mode
+
+
+@pytest.mark.parametrize(
+    "alt",
+    [-1000.0, -50.0, -0.05, 0.0, 100.0, 10000.0],
+)
+async def test_alt_accepts_negative_relative_altitudes(alt):
+    # MAVLink relative_alt is signed. Negative values are real:
+    # rooftop-to-street descent, GPS noise around home, valley flight.
+    data = _valid_data()
+    data["alt"] = alt
+    payload = TelemetryPayload(**data)
+    assert payload.alt == alt


### PR DESCRIPTION
- flight_mode: closed Literal -> pattern r"^[A-Z0-9_]+$" (max 32 chars). Decouples cloud schema from per-firmware mode catalogs and accepts UNKNOWN during the boot window before first HEARTBEAT.
- alt: ge=0 -> ge=-1000 to allow rooftop-takeoff descents, valley/mine surveys, and GPS noise around home. MAVLink relative_alt is signed.
- Tests pin both rejection and acceptance boundaries for both fields.
- Docs: README endpoints/auth section, project structure refresh, devlog entries for the auth setup (PR #44) and this relaxation.